### PR TITLE
Cache: stream sorted periods

### DIFF
--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/accountingtroll/cache/AccountingManagerCache.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/accountingtroll/cache/AccountingManagerCache.java
@@ -76,14 +76,16 @@ public class AccountingManagerCache {
 
     public Stream<ATBookYear> streamBookYears() {
         this.cacheBookYears();
-        return bookYearsByShortName.values().stream();
+        return bookYearsByShortName.values().stream()
+                .sorted();
     }
 
     public Stream<ATBookPeriod> streamPeriods() {
         this.cacheBookPeriods();
         return bookPeriodsByBookYearShortName.values()
                 .stream()
-                .flatMap(List::stream);
+                .flatMap(List::stream)
+                .sorted();
     }
 
     public Stream<ATThirdParty> streamThirdParties() {


### PR DESCRIPTION
Sort book years/periods when streaming, so that the balance spliterator works without having to wait for next accountingtroll release