### PR TITLE
Root path mappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>be.valuya.winbooks</groupId>
     <artifactId>winbooks-java-parent</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/winbooks-api-client/pom.xml
+++ b/winbooks-api-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>be.valuya.winbooks</groupId>
         <artifactId>winbooks-java-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>winbooks-api-client</artifactId>
 

--- a/winbooks-api-extra/pom.xml
+++ b/winbooks-api-extra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>be.valuya.winbooks</groupId>
         <artifactId>winbooks-java-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>winbooks-api-extra</artifactId>
 

--- a/winbooks-api-extra/pom.xml
+++ b/winbooks-api-extra/pom.xml
@@ -111,6 +111,7 @@
                                 <winbooks.test.ftp.user.name>${winbooks.test.ftp.user.name}
                                 </winbooks.test.ftp.user.name>
                                 <winbooks.test.ftp.password>${winbooks.test.ftp.password}</winbooks.test.ftp.password>
+                                <winbooks.test.ftp.path.mappings>${winbooks.test.ftp.path.mappings}</winbooks.test.ftp.path.mappings>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -127,12 +128,13 @@
                         <version>1.4.1</version>
                         <executions>
                             <execution>
-                                <id>download-pariflux-data</id>
+                                <id>download-parfilux-data</id>
                                 <phase>generate-test-resources</phase>
                                 <goals>
                                     <goal>wget</goal>
                                 </goals>
                                 <configuration>
+                                    <!-- Delete ~/.m2/repository/.cache/download-maven-plugin directory in case of CachedFileEntry error-->
                                     <url>
                                         https://nexus.valuya.be/nexus/repository/raw-public/accounting/data/winbooks-demo-dossier-pariflux-2019.zip
                                     </url>
@@ -152,8 +154,7 @@
                                 be.valuya.winbooks.api.ParfiluxDossierCategory
                             </groups>
                             <systemPropertyVariables>
-                                <winbooks.test.folder>${project.build.directory}/winbooks/Parfilux
-                                </winbooks.test.folder>
+                                <winbooks.test.folder>${project.build.directory}/winbooks</winbooks.test.folder>
                                 <winbooks.test.base.name>PARFILUX</winbooks.test.base.name>
                             </systemPropertyVariables>
                         </configuration>

--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManager.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManager.java
@@ -18,7 +18,6 @@ import be.valuya.winbooks.domain.error.WinbooksError;
 import be.valuya.winbooks.domain.error.WinbooksException;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -120,7 +119,10 @@ public class WinbooksTrollAccountingManager implements AccountingManager {
             throw new WinbooksException(WinbooksError.USER_FILE_ERROR, "Document path is absolute");
         }
 
-        Path baseFolderPath = fileConfiguration.getBaseFolderPath();
+        Path rootPath = fileConfiguration.getRootPath();
+        String basePathName = fileConfiguration.getBasePathName();
+        Path baseFolderPath = rootPath.resolve(basePathName);
+
         Path documentDirectoryPath = baseFolderPath.resolve(DOCUMENTS_PATH_NAME)
                 .resolve(DOCUMENT_UPLOAD_PATH_NAME)
                 .resolve(documentRelativePathName)

--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/WinbooksExtraService.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/WinbooksExtraService.java
@@ -70,8 +70,8 @@ public class WinbooksExtraService {
      * @param rootPath The path under which dossier directories are located
      * @param baseName The company base name, which is the dossier directory name as well as the reference used in winbooks.
      */
-    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String baseName) throws WinbooksConfigurationException {
-        return createWinbooksFileConfigurationOptional(rootPath, baseName, Map.of());
+    public WinbooksFileConfiguration createWinbooksFileConfiguration(Path rootPath, String baseName) throws WinbooksConfigurationException {
+        return createWinbooksFileConfiguration(rootPath, baseName, Map.of());
     }
 
     /**
@@ -81,8 +81,8 @@ public class WinbooksExtraService {
      * @param baseName     The company base name, which is the dossier directory name as well as the reference used in winbooks.
      * @param pathMappings Path mappings. See {@link WinbooksFileConfiguration#setPathMappings(Map)}.
      */
-    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String baseName, Map<String, Path> pathMappings) throws WinbooksConfigurationException {
-        return createWinbooksFileConfigurationOptional(rootPath, baseName, baseName, pathMappings);
+    public WinbooksFileConfiguration createWinbooksFileConfiguration(Path rootPath, String baseName, Map<String, Path> pathMappings) throws WinbooksConfigurationException {
+        return createWinbooksFileConfiguration(rootPath, baseName, baseName, pathMappings);
     }
 
     /**
@@ -93,7 +93,7 @@ public class WinbooksExtraService {
      * @param companyName  The company name, as used in winbooks reference.
      * @param pathMappings Path mappings. See {@link WinbooksFileConfiguration#setPathMappings(Map)}.
      */
-    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String basePathName, String companyName, Map<String, Path> pathMappings) throws WinbooksConfigurationException {
+    public WinbooksFileConfiguration createWinbooksFileConfiguration(Path rootPath, String basePathName, String companyName, Map<String, Path> pathMappings) throws WinbooksConfigurationException {
         WinbooksFileConfiguration winbooksFileConfiguration = new WinbooksFileConfiguration();
         winbooksFileConfiguration.setRootPath(rootPath);
         winbooksFileConfiguration.setBasePathName(basePathName);

--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/WinbooksExtraService.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/WinbooksExtraService.java
@@ -81,7 +81,7 @@ public class WinbooksExtraService {
      * @param baseName     The company base name, which is the dossier directory name as well as the reference used in winbooks.
      * @param pathMappings Path mappings. See {@link WinbooksFileConfiguration#setPathMappings(Map)}.
      */
-    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String baseName, Map<Path, Path> pathMappings) throws WinbooksConfigurationException {
+    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String baseName, Map<String, Path> pathMappings) throws WinbooksConfigurationException {
         return createWinbooksFileConfigurationOptional(rootPath, baseName, baseName, pathMappings);
     }
 
@@ -93,7 +93,7 @@ public class WinbooksExtraService {
      * @param companyName  The company name, as used in winbooks reference.
      * @param pathMappings Path mappings. See {@link WinbooksFileConfiguration#setPathMappings(Map)}.
      */
-    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String basePathName, String companyName, Map<Path, Path> pathMappings) throws WinbooksConfigurationException {
+    public WinbooksFileConfiguration createWinbooksFileConfigurationOptional(Path rootPath, String basePathName, String companyName, Map<String, Path> pathMappings) throws WinbooksConfigurationException {
         WinbooksFileConfiguration winbooksFileConfiguration = new WinbooksFileConfiguration();
         winbooksFileConfiguration.setRootPath(rootPath);
         winbooksFileConfiguration.setBasePathName(basePathName);

--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/config/WinbooksFileConfiguration.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/config/WinbooksFileConfiguration.java
@@ -17,7 +17,7 @@ public class WinbooksFileConfiguration {
     private String winbooksCompanyName;
     private Charset charset = StandardCharsets.ISO_8859_1;
     // Maps path across filesystems.
-    private Map<Path, Path> pathMappings = new HashMap<>();
+    private Map<String, Path> pathMappings = new HashMap<>();
 
     private boolean ignoreConversionErrors = true;
     private boolean ignoreMissingArchives = true;
@@ -177,7 +177,7 @@ public class WinbooksFileConfiguration {
         this.ignoreConversionErrors = ignoreConversionErrors;
     }
 
-    public Map<Path, Path> getPathMappings() {
+    public Map<String, Path> getPathMappings() {
         return pathMappings;
     }
 
@@ -192,23 +192,22 @@ public class WinbooksFileConfiguration {
      * the archive directory from the above example to an ftp filesystem:
      *
      * <pre>{@code
-     *   Path archivePath = Paths.get("C:\\winbooks_archives");
+     *   String archivePath = "C:\\winbooks_archives";
      *   Path ftpArchivePath = Paths.get("ftp://archives.winbooks.local");
-     *   Map<Path, Path> mappings = Map.of(archivePath, ftpArchivePath);
+     *   Map<String, Path> mappings = Map.of(archivePath, ftpArchivePath);
      * }</pre>
      *
      * <p></p>
      * When winbooks-java encounters a path, it will iterate over this map to resolve the path from the
      * correct filesystem. If a key of this map happens to be a parent of the encoutered path, this later
      * path will be relativized, then resolved against the map value Path. Paths will be normalized to
-     * forward-slash separators beforehand, so a Path with a single name like 'C:\some\windows\path' or
-     * '\\some-smb-host\some-path' is a valid map key.
+     * forward-slash unix-filesystem paths before comparison.
      *
      * @param pathMappings A map used to resolve paths present in the winbooks tables.
-     *                     Keys contain the path expected to be present in the tables.
+     *                     Keys contain the path expected to be present in the tables, as string.
      *                     Values contain the path from which resolution will be performed.
      */
-    public void setPathMappings(Map<Path, Path> pathMappings) {
+    public void setPathMappings(Map<String, Path> pathMappings) {
         this.pathMappings = pathMappings;
     }
 }

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksParfiluxDossierTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksParfiluxDossierTest.java
@@ -63,7 +63,7 @@ public class WinbooksParfiluxDossierTest {
         String baseName = System.getProperty("winbooks.test.base.name");
 
         Path baseFolderPath = Paths.get(baseFolderLocation);
-        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName);
+        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfiguration(baseFolderPath, baseName);
         winbooksFileConfiguration.setReadTablesToMemory(true);
 
         trollSrervice = new WinbooksTrollAccountingManager(winbooksFileConfiguration);

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksParfiluxDossierTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksParfiluxDossierTest.java
@@ -13,6 +13,7 @@ import be.valuya.winbooks.api.ParfiluxDossierCategory;
 import be.valuya.winbooks.api.accountingtroll.converter.ATThirdPartyIdFactory;
 import be.valuya.winbooks.api.extra.WinbooksExtraService;
 import be.valuya.winbooks.api.extra.config.WinbooksFileConfiguration;
+import be.valuya.winbooks.domain.error.WinbooksConfigurationException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -55,15 +56,14 @@ public class WinbooksParfiluxDossierTest {
     }
 
     @Before
-    public void before() {
+    public void before() throws WinbooksConfigurationException {
         WinbooksExtraService extraService = new WinbooksExtraService();
 
         String baseFolderLocation = System.getProperty("winbooks.test.folder");
         String baseName = System.getProperty("winbooks.test.base.name");
 
         Path baseFolderPath = Paths.get(baseFolderLocation);
-        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName)
-                .orElseThrow(AssertionError::new);
+        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName);
         winbooksFileConfiguration.setReadTablesToMemory(true);
 
         trollSrervice = new WinbooksTrollAccountingManager(winbooksFileConfiguration);

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerFtpTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerFtpTest.java
@@ -5,6 +5,7 @@ import be.valuya.winbooks.api.FtpWinbooksDossierCategory;
 import be.valuya.winbooks.api.extra.WinbooksExtraService;
 import be.valuya.winbooks.api.extra.config.DocumentMatchingMode;
 import be.valuya.winbooks.api.extra.config.WinbooksFileConfiguration;
+import be.valuya.winbooks.domain.error.WinbooksConfigurationException;
 import com.github.robtimus.filesystems.ftp.ConnectionMode;
 import com.github.robtimus.filesystems.ftp.FTPEnvironment;
 import org.junit.AfterClass;
@@ -70,15 +71,14 @@ public class WinbooksTrollAccountingManagerFtpTest {
     }
 
     @Before
-    public void setup() {
+    public void setup() throws WinbooksConfigurationException {
         WinbooksExtraService winbooksExtraService = new WinbooksExtraService();
 
         String uriStr = MessageFormat.format("{0}://{1}@{2}", PROTOCOL, FTP_USER_NAME, FTP_HOST_NAME);
         URI uri = URI.create(uriStr);
         Path ftpBasePath = Paths.get(uri)
                 .resolve(FTP_PATH_NAME);
-        WinbooksFileConfiguration winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(ftpBasePath, BASE_NAME)
-                .orElseThrow(AssertionError::new);
+        WinbooksFileConfiguration winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(ftpBasePath, BASE_NAME);
         winbooksFileConfiguration.setDocumentMatchingMode(DocumentMatchingMode.EAGERLY_CACHE_ALL_DOCUMENTS);
         winbooksFileConfiguration.setResolveArchivedBookYears(true);
         winbooksFileConfiguration.setResolveDocumentTimes(false);

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerFtpTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerFtpTest.java
@@ -78,7 +78,7 @@ public class WinbooksTrollAccountingManagerFtpTest {
         URI uri = URI.create(uriStr);
         Path ftpBasePath = Paths.get(uri)
                 .resolve(FTP_PATH_NAME);
-        WinbooksFileConfiguration winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(ftpBasePath, BASE_NAME);
+        WinbooksFileConfiguration winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfiguration(ftpBasePath, BASE_NAME);
         winbooksFileConfiguration.setDocumentMatchingMode(DocumentMatchingMode.EAGERLY_CACHE_ALL_DOCUMENTS);
         winbooksFileConfiguration.setResolveArchivedBookYears(true);
         winbooksFileConfiguration.setResolveDocumentTimes(false);

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerLocalTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerLocalTest.java
@@ -37,7 +37,7 @@ public class WinbooksTrollAccountingManagerLocalTest {
 
         Path baseFolderPath = Paths.get(baseFolderLocation)
                 .resolve(baseName);
-        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName);
+        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfiguration(baseFolderPath, baseName);
         winbooksFileConfiguration.setDocumentMatchingMode(DocumentMatchingMode.EAGERLY_CACHE_ALL_DOCUMENTS);
         winbooksFileConfiguration.setResolveArchivedBookYears(true);
 

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerLocalTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/accountingtroll/WinbooksTrollAccountingManagerLocalTest.java
@@ -6,6 +6,7 @@ import be.valuya.winbooks.api.LocalWinbooksDossierCategory;
 import be.valuya.winbooks.api.extra.WinbooksExtraService;
 import be.valuya.winbooks.api.extra.config.DocumentMatchingMode;
 import be.valuya.winbooks.api.extra.config.WinbooksFileConfiguration;
+import be.valuya.winbooks.domain.error.WinbooksConfigurationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -28,7 +29,7 @@ public class WinbooksTrollAccountingManagerLocalTest {
     private AccountingEventListener eventListener;
 
     @Before
-    public void setup() {
+    public void setup() throws WinbooksConfigurationException {
         WinbooksExtraService extraService = new WinbooksExtraService();
 
         String baseFolderLocation = System.getProperty("winbooks.test.folder");
@@ -36,8 +37,7 @@ public class WinbooksTrollAccountingManagerLocalTest {
 
         Path baseFolderPath = Paths.get(baseFolderLocation)
                 .resolve(baseName);
-        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName)
-                .orElseThrow(AssertionError::new);
+        WinbooksFileConfiguration winbooksFileConfiguration = extraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName);
         winbooksFileConfiguration.setDocumentMatchingMode(DocumentMatchingMode.EAGERLY_CACHE_ALL_DOCUMENTS);
         winbooksFileConfiguration.setResolveArchivedBookYears(true);
 

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceFtpTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceFtpTest.java
@@ -35,9 +35,9 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -103,9 +103,9 @@ public class WinbooksExtraServiceFtpTest {
         winbooksFileConfiguration.setResolveArchivedBookYears(true);
 
 
-        Map<Path, Path> pathMappings = Arrays.stream(ROOT_PATH_MAPPINGS.split(","))
+        Map<String, Path> pathMappings = Arrays.stream(ROOT_PATH_MAPPINGS.split(","))
                 .collect(Collectors.toMap(
-                        mappingName -> Paths.get(mappingName),
+                        Function.identity(),
                         mappingName -> ftpBasePath
                 ));
         winbooksFileConfiguration.setPathMappings(pathMappings);

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceFtpTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceFtpTest.java
@@ -98,7 +98,7 @@ public class WinbooksExtraServiceFtpTest {
         URI uri = URI.create(uriStr);
         Path ftpBasePath = Paths.get(uri)
                 .resolve(FTP_PATH_NAME);
-        winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(ftpBasePath, BASE_NAME);
+        winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfiguration(ftpBasePath, BASE_NAME);
         winbooksFileConfiguration.setReadTablesToMemory(true);
         winbooksFileConfiguration.setResolveArchivedBookYears(true);
 

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceLocalTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceLocalTest.java
@@ -10,6 +10,7 @@ import be.valuya.jbooks.model.WbEntry;
 import be.valuya.jbooks.model.WbPeriod;
 import be.valuya.winbooks.api.LocalWinbooksDossierCategory;
 import be.valuya.winbooks.api.extra.config.WinbooksFileConfiguration;
+import be.valuya.winbooks.domain.error.WinbooksConfigurationException;
 import be.valuya.winbooks.domain.error.WinbooksError;
 import be.valuya.winbooks.domain.error.WinbooksException;
 import com.lowagie.text.pdf.PdfReader;
@@ -45,18 +46,16 @@ public class WinbooksExtraServiceLocalTest {
 
 
     @Before
-    public void setup() {
+    public void setup() throws WinbooksConfigurationException {
         winbooksExtraService = new WinbooksExtraService();
 
-        String baseFolderLocation = System.getProperty("winbooks.test.folder");
+        String rootPath = System.getProperty("winbooks.test.folder");
+//        String basePath = System.getProperty("winbooks.test.base.path");
         String baseName = System.getProperty("winbooks.test.base.name");
 
-        Path baseFolderPath = Paths.get(baseFolderLocation)
-                .resolve(baseName);
-        winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(baseFolderPath, baseName)
-                .orElseThrow(AssertionError::new);
+        winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(
+                Paths.get(rootPath), baseName, Map.of());
         winbooksFileConfiguration.setReadTablesToMemory(true);
-
     }
 
     @Test
@@ -71,7 +70,7 @@ public class WinbooksExtraServiceLocalTest {
     public void testStreamDocumentPageData() throws Exception {
         WbDocument testDocument = winbooksExtraService.streamBookYears(winbooksFileConfiguration)
                 .flatMap(year -> winbooksExtraService.streamBookYearDocuments(winbooksFileConfiguration, year))
-                .filter(doc -> doc.getPageCount() > 1)
+                .filter(doc -> doc.getPageCount() > 0)
                 .findAny()
                 .orElseThrow(AssertionError::new);
 

--- a/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceLocalTest.java
+++ b/winbooks-api-extra/src/test/java/be/valuya/winbooks/api/extra/WinbooksExtraServiceLocalTest.java
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.math.BigDecimal;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.text.ParseException;
@@ -53,7 +52,7 @@ public class WinbooksExtraServiceLocalTest {
 //        String basePath = System.getProperty("winbooks.test.base.path");
         String baseName = System.getProperty("winbooks.test.base.name");
 
-        winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfigurationOptional(
+        winbooksFileConfiguration = winbooksExtraService.createWinbooksFileConfiguration(
                 Paths.get(rootPath), baseName, Map.of());
         winbooksFileConfiguration.setReadTablesToMemory(true);
     }

--- a/winbooks-domain/pom.xml
+++ b/winbooks-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>be.valuya.winbooks</groupId>
         <artifactId>winbooks-java-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>winbooks-domain</artifactId>
     <properties>

--- a/winbooks-domain/src/main/java/be/valuya/winbooks/domain/error/ArchivePathNotFoundException.java
+++ b/winbooks-domain/src/main/java/be/valuya/winbooks/domain/error/ArchivePathNotFoundException.java
@@ -6,17 +6,12 @@ import java.nio.file.Path;
 
 public class ArchivePathNotFoundException extends Exception {
 
-    private Path baseFolderPath;
     private WbBookYearFull wbBookYearFull;
 
-    public ArchivePathNotFoundException(Path baseFolderPath, WbBookYearFull wbBookYearFull) {
-        super("No archive directory found for base path " + baseFolderPath.toString() + " and book year " + wbBookYearFull.toString());
-        this.baseFolderPath = baseFolderPath;
+    public ArchivePathNotFoundException(WbBookYearFull wbBookYearFull) {
+        super("No archive directory found for book year " + wbBookYearFull.toString() + " : "
+                + wbBookYearFull.getArchivePathNameOptional().orElse("No archive path"));
         this.wbBookYearFull = wbBookYearFull;
-    }
-
-    public Path getBaseFolderPath() {
-        return baseFolderPath;
     }
 
     public WbBookYearFull getWbBookYearFull() {

--- a/winbooks-domain/src/main/java/be/valuya/winbooks/domain/error/WinbooksConfigurationException.java
+++ b/winbooks-domain/src/main/java/be/valuya/winbooks/domain/error/WinbooksConfigurationException.java
@@ -1,0 +1,32 @@
+package be.valuya.winbooks.domain.error;
+
+/**
+ * @author Yannick Majoros <yannick@valuya.be>
+ */
+public class WinbooksConfigurationException extends Exception {
+
+    private WinbooksError winbooksError;
+
+    public WinbooksConfigurationException(WinbooksError winbooksError) {
+        this.winbooksError = winbooksError;
+    }
+
+    public WinbooksConfigurationException(WinbooksError winbooksError, String message) {
+        super(message);
+        this.winbooksError = winbooksError;
+    }
+
+    public WinbooksConfigurationException(WinbooksError winbooksError, String message, Throwable cause) {
+        super(message, cause);
+        this.winbooksError = winbooksError;
+    }
+
+    public WinbooksConfigurationException(WinbooksError winbooksError, Throwable cause) {
+        super(cause);
+        this.winbooksError = winbooksError;
+    }
+
+    public WinbooksError getWinbooksError() {
+        return winbooksError;
+    }
+}


### PR DESCRIPTION
Paths from winbooks tables were only used for book year archives folders. There are some other in the param table, but those are not used yet.

Those paths are now relativized against a map of Path mappings. Previously the last part was used and resolved against the dossier parent path. Paths are converted to unix-path for comparison. 

Other changes include:
- Exception is thrown for invalid configuration, rather than an empty Optional. This allow to get insight of what went wrong.
- Root path (containing all dossiers), base path (a dossier path name), and company base name (the winbooks reference) are now splitted.
- Attempt to open a table file is done is two steps:
 1) using the path name as the file prefix (/SOMECOMPANY-12/SOMECOMPANY-12_table.dbf),
 2) using the company base name as the file prefix (/SOMECOMPANY-12/SOMECOMPANY_table.dbf).
Im not sure this was required, but it accounts for dossiers renamed/moved to other locations. It may introduce some performance loss, especially when case-insensitive siblings are resolved, although the former case seems to be the most likely used one.