### PR TITLE
Table paths caches: Do not share resolved table filenames for differe…

### DIFF
--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/TableBasePath.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/TableBasePath.java
@@ -1,0 +1,43 @@
+package be.valuya.winbooks.api.extra;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class TableBasePath {
+    private String tableName;
+    private Path basePath;
+
+    public TableBasePath(String tableName, Path basePath) {
+        this.tableName = tableName;
+        this.basePath = basePath;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public Path getBasePath() {
+        return basePath;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TableBasePath that = (TableBasePath) o;
+        return Objects.equals(tableName, that.tableName) && Objects.equals(basePath, that.basePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableName, basePath);
+    }
+
+    @Override
+    public String toString() {
+        return "TableBasePath{" +
+                "tableName='" + tableName + '\'' +
+                ", basePath=" + basePath +
+                '}';
+    }
+}

--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/WinbooksExtraService.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/extra/WinbooksExtraService.java
@@ -54,13 +54,13 @@ public class WinbooksExtraService {
     private static final int ACCOUNT_NUMBER_DEFAULT_LENGTH = 6;
 
     // some invalid String that Winbooks likes to have
-    private static final String CHAR0_STRING = Character.toString((char) 0);
+    private static final String NULL_CHAR0_STRING = Character.toString((char) 0);
     private static final String DBF_EXTENSION = ".dbf";
     private static final DateTimeFormatter PERIOD_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
 
 
     private final WinbooksDocumentsService documentService = new WinbooksDocumentsService();
-    private final Map<String, Path> tableFilePathMap = new HashMap<>();
+    private final Map<TableBasePath, Path> tableFilePathMap = new HashMap<>();
 
 
     /**
@@ -481,7 +481,7 @@ public class WinbooksExtraService {
     }
 
     private boolean isWbValidString(String str) {
-        return str == null || !str.startsWith(CHAR0_STRING);
+        return str == null || !str.startsWith(NULL_CHAR0_STRING);
     }
 
 
@@ -626,7 +626,8 @@ public class WinbooksExtraService {
     }
 
     private Path resolveTablePathOrThrow(WinbooksFileConfiguration winbooksFileConfiguration, Path basePath, String tableName) {
-        Path existingPath = tableFilePathMap.get(tableName);
+        TableBasePath tableBasePath = new TableBasePath(tableName, basePath);
+        Path existingPath = tableFilePathMap.get(tableBasePath);
         if (existingPath != null) {
             return existingPath;
         }
@@ -654,8 +655,8 @@ public class WinbooksExtraService {
                     String message = MessageFormat.format("Could not find table {0} in folder {1}", tableName, baseFolderPathName);
                     return new WinbooksException(WinbooksError.DOSSIER_NOT_FOUND, message);
                 });
-        tableFilePathMap.put(tableName, tablePath);
-        LOGGER.info("Found table " + tableName + " at " + tablePath.toString());
+        tableFilePathMap.put(tableBasePath, tablePath);
+        LOGGER.info("Found table base path " + tableBasePath + " at " + tablePath.toString());
         return tablePath;
     }
 


### PR DESCRIPTION
…nt basePaths.

As table names may need to be resolved (case-incensitive siblings, multiple possible base filename (dossier name, dossier-name + year, ...), ...), which can be costly on remote filesystems, a cache was introduced.

Recently, unification to resolve the dossier path for a given book year was adapted, and data for an archived book year were always fetched from the book year dossier directory, using the same logic than the documents, since the documents are located there.
This later changes made it so that tables read for the first book year (usually the oldest one) were resolved for the archived book year directory, and the path cached. 
When attempting to read the same table for subsequent book years, the old table was always returned, and so the same data were returned for every book year.

This fix updates the cache key to contain the base folder in addition to the table name. Querying a single table for different book years will not hit the cache, unless the book years share the same base path. Usually, 2 book years are deemed active and kept open in the company base directory, while others are archived and have each their own directory.