### PR TITLE
Archives fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>be.valuya.winbooks</groupId>
     <artifactId>winbooks-java-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/winbooks-api-client/pom.xml
+++ b/winbooks-api-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>be.valuya.winbooks</groupId>
         <artifactId>winbooks-java-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>winbooks-api-client</artifactId>
 

--- a/winbooks-api-extra/pom.xml
+++ b/winbooks-api-extra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>be.valuya.winbooks</groupId>
         <artifactId>winbooks-java-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>winbooks-api-extra</artifactId>
 

--- a/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/accountingtroll/converter/ATThirdPartyConverter.java
+++ b/winbooks-api-extra/src/main/java/be/valuya/winbooks/api/accountingtroll/converter/ATThirdPartyConverter.java
@@ -69,6 +69,9 @@ public class ATThirdPartyConverter {
         Optional.ofNullable(dossierThirdParty.getName())
                 .ifPresent(thirdParty::setFullName);
 
+        Optional.ofNullable(dossierThirdParty.getCode())
+                .ifPresent(thirdParty::setAccountingReference);
+
         String fullAddress = Stream.of(dossierThirdParty.getAddress1(), dossierThirdParty.getAddress2())
                 .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.joining("\n"));
@@ -84,6 +87,8 @@ public class ATThirdPartyConverter {
                 .ifPresent(thirdParty::setCountryCode);
         Optional.ofNullable(dossierThirdParty.getVatNumber())
                 .ifPresent(thirdParty::setVatNumber);
+
+        // TODO: needs to read more from the params table to fill other fields
 
         return thirdParty;
     }

--- a/winbooks-domain/pom.xml
+++ b/winbooks-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>be.valuya.winbooks</groupId>
         <artifactId>winbooks-java-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>winbooks-domain</artifactId>
     <properties>


### PR DESCRIPTION
extra service includes a method to list winbooks dossier path from the configured root paths, and filter all path names to exclude archives and/or invalid paths, depending on parameters.

When including the archive paths, the validity check was broken. This change fixes that.